### PR TITLE
[WIP] Bump pytorch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,11 @@ natsort
 numpy
 scipy
 matplotlib
-torch<1.7.0
-torchvision<0.8.0
 nnutils-pytorch
-pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@1d3724a
+pytorch-lightning
+torch==1.12
+torchvision==0.12
+torchaudio==0.12
 jsonargparse[signatures]
 dataclasses; python_version < '3.7'
 pandas


### PR DESCRIPTION
PyLaia currently requires an old version of Pytorch (1.6 - the latest version is 1.12). This is because PyLaia depends on [nnutils](https://github.com/jpuigcerver/nnutils), that supports only Pytorch 1.6. 

To bump the Pytorch version, we need to:

- release wheels for nnutils to support the latest Pytorch version (I have made a [contribution request](https://github.com/jpuigcerver/nnutils/issues/7) to do that)
- update the `requirements.txt` for PyLaia
- update the code and tests to make it compatible with Pytorch 1.12 (this should be easy, PyLaia does not depend on deprecated functions)