### PR TITLE
Language model support

### DIFF
--- a/laia/__init__.py
+++ b/laia/__init__.py
@@ -14,7 +14,7 @@ import laia.nn
 import laia.utils
 
 __all__ = ["__version__", "__root__", "get_installed_versions"]
-__version__ = "1.0.1.dev0"
+__version__ = "1.0.2"
 __root__ = Path(__file__).parent.parent
 
 try:

--- a/laia/callbacks/decode.py
+++ b/laia/callbacks/decode.py
@@ -60,9 +60,10 @@ class Decode(pl.Callback):
         self.include_img_ids = include_img_ids
         self.print_line_confidence_scores = print_line_confidence_scores
         self.print_word_confidence_scores = print_word_confidence_scores
-        self.print_confidence_scores = (
-            self.print_word_confidence_scores or self.print_line_confidence_scores
-        )
+
+    @property
+    def print_confidence_scores(self):
+        return self.print_word_confidence_scores or self.print_line_confidence_scores
 
     def on_test_batch_end(self, trainer, pl_module, outputs, batch, *args):
         super().on_test_batch_end(trainer, pl_module, outputs, batch, *args)
@@ -76,6 +77,11 @@ class Decode(pl.Callback):
                 compute_word_prob(self.syms, hyp, prob, self.input_space)
                 for hyp, prob in zip(hyps, probs)
             ]
+
+        else:
+            probs = []
+            line_probs = []
+            word_probs = []
 
         for i, (img_id, hyp) in enumerate(zip(img_ids, hyps)):
 

--- a/laia/callbacks/decode.py
+++ b/laia/callbacks/decode.py
@@ -60,25 +60,24 @@ class Decode(pl.Callback):
         self.include_img_ids = include_img_ids
         self.print_line_confidence_scores = print_line_confidence_scores
         self.print_word_confidence_scores = print_word_confidence_scores
+        self.print_confidence_scores = (
+            self.print_word_confidence_scores or self.print_line_confidence_scores
+        )
 
     def on_test_batch_end(self, trainer, pl_module, outputs, batch, *args):
         super().on_test_batch_end(trainer, pl_module, outputs, batch, *args)
         img_ids = pl_module.batch_id_fn(batch)
         hyps = self.decoder(outputs)["hyp"]
-        probs = self.decoder(outputs)["prob-htr-char"]
 
-        # compute mean confidence score
-        line_probs = [np.mean(prob) for prob in probs]
+        if self.print_confidence_scores:
+            probs = self.decoder(outputs)["prob-htr-char"]
+            line_probs = [np.mean(prob) for prob in probs]
+            word_probs = [
+                compute_word_prob(self.syms, hyp, prob, self.input_space)
+                for hyp, prob in zip(hyps, probs)
+            ]
 
-        # compute mean confidence score by word
-        word_probs = [
-            compute_word_prob(self.syms, hyp, prob, self.input_space)
-            for hyp, prob in zip(hyps, probs)
-        ]
-
-        for i, (img_id, hyp, line_prob, word_prob) in enumerate(
-            zip(img_ids, hyps, line_probs, word_probs)
-        ):
+        for i, (img_id, hyp) in enumerate(zip(img_ids, hyps)):
 
             if self.use_symbols:
                 hyp = [self.syms[v] for v in hyp]
@@ -88,22 +87,25 @@ class Decode(pl.Callback):
                         for sym in hyp
                     ]
             if self.join_string is not None:
-                hyp = self.join_string.join(str(x) for x in hyp)
+                hyp = self.join_string.join(str(x) for x in hyp).strip()
 
-            if self.print_line_confidence_scores:
-                self.write(
-                    f"{img_id}{self.separator}{line_prob:.2f}{self.separator}{hyp}"
-                    if self.include_img_ids
-                    else f"{line_prob:.2f}{self.separator}{hyp}"
-                )
+            if self.print_confidence_scores:
 
-            elif self.print_word_confidence_scores:
-                word_prob = [f"{prob:.2f}" for prob in word_prob]
-                self.write(
-                    f"{img_id}{self.separator}{word_prob}{self.separator}{hyp}"
-                    if self.include_img_ids
-                    else f"{word_prob}{self.separator}{hyp}"
-                )
+                if self.print_word_confidence_scores:
+                    word_prob = [f"{prob:.2f}" for prob in word_probs[i]]
+                    self.write(
+                        f"{img_id}{self.separator}{word_prob}{self.separator}{hyp}"
+                        if self.include_img_ids
+                        else f"{word_prob}{self.separator}{hyp}"
+                    )
+
+                else:
+                    line_prob = line_probs[i]
+                    self.write(
+                        f"{img_id}{self.separator}{line_prob:.2f}{self.separator}{hyp}"
+                        if self.include_img_ids
+                        else f"{line_prob:.2f}{self.separator}{hyp}"
+                    )
 
             else:
                 self.write(

--- a/laia/common/arguments.py
+++ b/laia/common/arguments.py
@@ -321,6 +321,13 @@ class DecodeArgs:
     segmentation: Optional[Segmentation] = None
     print_line_confidence_scores: bool = False
     print_word_confidence_scores: bool = False
+    use_language_model: bool = False
+    language_model_path: str = None
+    language_model_weight: float = None
+    tokens_path: str = None
+    lexicon_path: str = None
+    unk_token: str = "<unk>"
+    blank_token: str = "<ctc>"
 
 
 @dataclass

--- a/laia/decoders/__init__.py
+++ b/laia/decoders/__init__.py
@@ -1,3 +1,4 @@
 from laia.decoders.ctc_alignment import ctc_alignment
 from laia.decoders.ctc_greedy_decoder import CTCGreedyDecoder
+from laia.decoders.ctc_language_decoder import CTCLanguageDecoder
 from laia.decoders.ctc_nbest_decoder import CTCNBestDecoder

--- a/laia/decoders/ctc_language_decoder.py
+++ b/laia/decoders/ctc_language_decoder.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, List
 
+import numpy as np
 import torch
 from torchaudio.models.decoder import ctc_decoder
-import numpy as np
 
 from laia.losses.ctc_loss import transform_batch
+
 
 class CTCLanguageDecoder:
     def __init__(
@@ -35,12 +36,12 @@ class CTCLanguageDecoder:
 
         x, xs = transform_batch(x)
         x = x.detach()
-    
+
         # no GPU support
         device = torch.device("cpu")
 
         # from (frame, bs, num_tokens) to (bs, frame, num_tokens)
-        x = x.permute((1, 0, 2))  
+        x = x.permute((1, 0, 2))
         x = torch.nn.functional.log_softmax(x, dim=-1)
         x = x.to(device)
 

--- a/laia/decoders/ctc_language_decoder.py
+++ b/laia/decoders/ctc_language_decoder.py
@@ -33,7 +33,6 @@ class CTCLanguageDecoder:
         self,
         x: Any,
     ) -> Dict[str, List]:
-
         x, xs = transform_batch(x)
         x = x.detach()
 
@@ -44,11 +43,14 @@ class CTCLanguageDecoder:
         x = x.permute((1, 0, 2))
         x = torch.nn.functional.log_softmax(x, dim=-1)
         x = x.to(device)
+        if isinstance(xs, list):
+            xs = torch.tensor(xs)
+            xs.to(device)
 
         # decode
         hypotheses = self.decoder(x, xs)
         out = {}
-        out["hyp"] = [hypothesis[0].tokens.tolist() for hypothesis in hypotheses]
+        out["hyp"] = [hypothesis[0].tokens.tolist()[1:-1] for hypothesis in hypotheses]
         # no character-based probability
         # however, a score can be accessed with hypothesis[0].score
         return out

--- a/laia/decoders/ctc_language_decoder.py
+++ b/laia/decoders/ctc_language_decoder.py
@@ -8,6 +8,21 @@ from laia.losses.ctc_loss import transform_batch
 
 
 class CTCLanguageDecoder:
+    """
+    Intialize a CTC decoder with n-gram language modeling.
+    Args:
+        language_model_path (str): path to a KenLM or ARPA language model
+        lexicon_path (str): path to a lexicon file containing the possible words and corresponding spellings.
+            Each line consists of a word and its space separated spelling. If `None`, uses lexicon-free
+            decoding.
+        tokens_path (str): path to a file containing valid tokens. If using a file, the expected
+            format is for tokens mapping to the same index to be on the same line
+        language_model_weight (float): weight of the language model.
+        blank_token (str): token representing the blank/ctc symbol
+        unk_token (str): token representing unknown characters
+        sil_token (str): token representing the space character
+    """
+
     def __init__(
         self,
         language_model_path: str,
@@ -31,26 +46,40 @@ class CTCLanguageDecoder:
 
     def __call__(
         self,
-        x: Any,
+        features: Any,
     ) -> Dict[str, List]:
-        x, xs = transform_batch(x)
-        x = x.detach()
+        """
+        Decode a feature vector using n-gram language modelling.
+        Args:
+            features (Any): feature vector of size (n_frame, batch_size, n_tokens).
+                Can be either a torch.tensor or a torch.nn.utils.rnn.PackedSequence
+        Returns:
+            out (Dict[str, List]): a dictionnary containing the hypothesis (the list of decoded tokens).
+                There is no character-based probability.
+        """
 
-        # no GPU support
+        # Get the actual size of each feature in the batch
+        batch_features, batch_sizes = transform_batch(features)
+        batch_features = batch_features.detach()
+
+        # Reshape from (n_frame, batch_size, n_tokens) to (batch_size, n_frame, n_tokens)
+        batch_features = batch_features.permute((1, 0, 2))
+
+        # Apply log softmax
+        batch_features = torch.nn.functional.log_softmax(batch_features, dim=-1)
+
+        # No GPU support for torchaudio's ctc_decoder
         device = torch.device("cpu")
+        batch_features = batch_features.to(device)
+        if isinstance(batch_sizes, list):
+            batch_sizes = torch.tensor(batch_sizes)
+            batch_sizes.to(device)
 
-        # from (frame, bs, num_tokens) to (bs, frame, num_tokens)
-        x = x.permute((1, 0, 2))
-        x = torch.nn.functional.log_softmax(x, dim=-1)
-        x = x.to(device)
-        if isinstance(xs, list):
-            xs = torch.tensor(xs)
-            xs.to(device)
+        # Decode
+        hypotheses = self.decoder(batch_features, batch_sizes)
 
-        # decode
-        hypotheses = self.decoder(x, xs)
+        # Format the output
         out = {}
-        out["hyp"] = [hypothesis[0].tokens.tolist()[1:-1] for hypothesis in hypotheses]
-        # no character-based probability
-        # however, a score can be accessed with hypothesis[0].score
+        out["hyp"] = [hypothesis[0].tokens.tolist() for hypothesis in hypotheses]
+        # you can get a log likelyhood with hypothesis[0].score
         return out

--- a/laia/decoders/ctc_language_decoder.py
+++ b/laia/decoders/ctc_language_decoder.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, List
+
+import torch
+from torchaudio.models.decoder import ctc_decoder
+import numpy as np
+
+from laia.losses.ctc_loss import transform_batch
+
+class CTCLanguageDecoder:
+    def __init__(
+        self,
+        language_model_path: str,
+        lexicon_path: str,
+        tokens_path: str,
+        language_model_weight: float = 1.0,
+        blank_token: str = "<ctc>",
+        unk_token: str = "<unk>",
+        sil_token: str = "<space>",
+    ):
+
+        self.decoder = ctc_decoder(
+            lm=language_model_path,
+            lexicon=lexicon_path,
+            tokens=tokens_path,
+            lm_weight=language_model_weight,
+            blank_token=blank_token,
+            unk_word=unk_token,
+            sil_token=sil_token,
+        )
+
+    def __call__(
+        self,
+        x: Any,
+    ) -> Dict[str, List]:
+
+        x, xs = transform_batch(x)
+        x = x.detach()
+    
+        # no GPU support
+        device = torch.device("cpu")
+
+        # from (frame, bs, num_tokens) to (bs, frame, num_tokens)
+        x = x.permute((1, 0, 2))  
+        x = torch.nn.functional.log_softmax(x, dim=-1)
+        x = x.to(device)
+
+        # decode
+        hypotheses = self.decoder(x, xs)
+        out = {}
+        out["hyp"] = [hypothesis[0].tokens.tolist() for hypothesis in hypotheses]
+        # no character-based probability
+        # however, a score can be accessed with hypothesis[0].score
+        return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ nnutils-pytorch-cuda
 pytorch-lightning==1.1.0
 torch==1.13
 torchvision==0.14
+torchaudio==0.13
 jsonargparse[signatures]==4.7
 dataclasses; python_version < '3.7'

--- a/tests/decoders/ctc_language_decoder_test.py
+++ b/tests/decoders/ctc_language_decoder_test.py
@@ -63,9 +63,11 @@ ngram 2=14
 
 
 @pytest.mark.parametrize(
-    ["input_tensor", "lm_weight", "expected_result"],
+    ["input_tensor", "lm_weight", "expected_string"],
     [
         (
+            # Simulate a feature vector of size (n_frame=4, batch_size=1, n_tokens=10)
+            # Line 1 corresponds to the first frame. The highest value corresponds to the most probable token (column index 6 => token "t")
             torch.tensor(
                 [
                     [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
@@ -78,6 +80,7 @@ ngram 2=14
             "tast",
         ),
         (
+            # For frame 2, tokens with index 1 and 2 are the most probable tokens (the model a feature vector of size (n_frame=4, batch_size=1, n_tokens=10)
             torch.tensor(
                 [
                     [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
@@ -91,7 +94,7 @@ ngram 2=14
         ),
     ],
 )
-def test_lm_decoding_weight(tmpdir, input_tensor, lm_weight, expected_result):
+def test_lm_decoding_weight(tmpdir, input_tensor, lm_weight, expected_string):
     tokens_path = Path(tmpdir) / "tokens.txt"
     lexicon_path = Path(tmpdir) / "lexicon.txt"
     arpa_path = Path(tmpdir) / "lm.arpa"
@@ -109,6 +112,8 @@ def test_lm_decoding_weight(tmpdir, input_tensor, lm_weight, expected_result):
     with open(tokens_path, "r") as f:
         tokens_char = f.read().splitlines()
 
-    r = decoder(input_tensor)
-    expected_result_index = [tokens_char.index(char) for char in expected_result]
-    assert r["hyp"][0] == expected_result_index
+    predicted_tokens = decoder(input_tensor)["hyp"][0]
+    predicted_string = "".join([tokens_char[char] for char in predicted_tokens])
+    predicted_string = predicted_string.replace("<space>", " ").strip()
+
+    assert predicted_string == expected_string

--- a/tests/decoders/ctc_language_decoder_test.py
+++ b/tests/decoders/ctc_language_decoder_test.py
@@ -1,6 +1,8 @@
-import torch
-import pytest
 from pathlib import Path
+
+import pytest
+import torch
+
 from laia.decoders import CTCLanguageDecoder
 
 tokens = """<ctc>
@@ -14,7 +16,7 @@ t
 <unk>
 <space>"""
 
-lexicon="""<ctc> <ctc>
+lexicon = """<ctc> <ctc>
 a a
 e e
 h h
@@ -25,7 +27,7 @@ t t
 <unk> <unk>
 <space> <space>"""
 
-arpa_lm="""\\data\\
+arpa_lm = """\\data\\
 ngram 1=10
 ngram 2=14
 
@@ -63,23 +65,31 @@ ngram 2=14
 @pytest.mark.parametrize(
     ["input_tensor", "lm_weight", "expected_result"],
     [
-        (torch.tensor([
-            [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
-            [[-2.1, -0.1, -0.3, -4.2, -5.0, -5.1, -4.7, -4.2, -5.2, -1.2]],
-            [[-2.1, -2.5, -4.1, -4.2, -5.0, -0.7, -0.9, -1.7, -5.2, -1.2]],
-            [[-2.1, -0.5, -4.1, -4.2, -5.0, -0.7, -0.1, -1.1, -5.2, -1.2]],
-        ]), 
-        0, 
-        "tast"
-    ), (torch.tensor(
-        [
-            [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
-            [[-2.1, -0.1, -0.3, -4.2, -5.0, -5.1, -4.7, -4.2, -5.2, -1.2]],
-            [[-2.1, -2.5, -4.1, -4.2, -5.0, -0.7, -0.9, -1.7, -5.2, -1.2]],
-            [[-2.1, -0.5, -4.1, -4.2, -5.0, -0.7, -0.1, -1.1, -5.2, -1.2]],
-        ]
-    ), 1, "test")
-    ]
+        (
+            torch.tensor(
+                [
+                    [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
+                    [[-2.1, -0.1, -0.3, -4.2, -5.0, -5.1, -4.7, -4.2, -5.2, -1.2]],
+                    [[-2.1, -2.5, -4.1, -4.2, -5.0, -0.7, -0.9, -1.7, -5.2, -1.2]],
+                    [[-2.1, -0.5, -4.1, -4.2, -5.0, -0.7, -0.1, -1.1, -5.2, -1.2]],
+                ]
+            ),
+            0,
+            "tast",
+        ),
+        (
+            torch.tensor(
+                [
+                    [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
+                    [[-2.1, -0.1, -0.3, -4.2, -5.0, -5.1, -4.7, -4.2, -5.2, -1.2]],
+                    [[-2.1, -2.5, -4.1, -4.2, -5.0, -0.7, -0.9, -1.7, -5.2, -1.2]],
+                    [[-2.1, -0.5, -4.1, -4.2, -5.0, -0.7, -0.1, -1.1, -5.2, -1.2]],
+                ]
+            ),
+            1,
+            "test",
+        ),
+    ],
 )
 def test_lm_decoding_weight(tmpdir, input_tensor, lm_weight, expected_result):
     tokens_path = Path(tmpdir) / "tokens.txt"
@@ -90,15 +100,15 @@ def test_lm_decoding_weight(tmpdir, input_tensor, lm_weight, expected_result):
     arpa_path.write_bytes(bytes(arpa_lm, "utf-8"))
 
     decoder = CTCLanguageDecoder(
-        language_model_path=str(arpa_path), 
-        tokens_path=str(tokens_path), 
+        language_model_path=str(arpa_path),
+        tokens_path=str(tokens_path),
         lexicon_path=str(lexicon_path),
-        language_model_weight=lm_weight
-        )
+        language_model_weight=lm_weight,
+    )
 
     with open(tokens_path, "r") as f:
         tokens_char = f.read().splitlines()
 
     r = decoder(input_tensor)
     expected_result_index = [tokens_char.index(char) for char in expected_result]
-    assert r["hyp"][0]==expected_result_index
+    assert r["hyp"][0] == expected_result_index

--- a/tests/decoders/ctc_language_decoder_test.py
+++ b/tests/decoders/ctc_language_decoder_test.py
@@ -1,0 +1,104 @@
+import torch
+import pytest
+from pathlib import Path
+from laia.decoders import CTCLanguageDecoder
+
+tokens = """<ctc>
+a
+e
+h
+i
+s
+t
+.
+<unk>
+<space>"""
+
+lexicon="""<ctc> <ctc>
+a a
+e e
+h h
+i i
+s s
+t t
+. .
+<unk> <unk>
+<space> <space>"""
+
+arpa_lm="""\\data\\
+ngram 1=10
+ngram 2=14
+
+\\1-grams:
+-1.09691\t.\t-0.2648178
+-1.09691\t</s>
+-99\t<s>\t-0.2253093
+-0.79588\t<space>\t-0.10721
+-1.09691\ta\t-0.2253093
+-1.09691\te\t-0.2253093
+-1.09691\th\t-0.2455126
+-0.9208187\ti\t-0.4014006
+-0.79588\ts\t-0.2304489
+-0.79588\tt\t-0.1818436
+
+\\2-grams:
+-0.30103\t. </s>
+-0.30103\t<s> t
+-0.7781513\t<space> a
+-0.7781513\t<space> i
+-0.7781513\t<space> t
+-0.30103\ta <space>
+-0.30103\te s
+-0.30103\th i
+-0.1760913\ti s
+-0.39794\ts <space>
+-0.69897\ts t
+-0.7781513\tt .
+-0.7781513\tt e
+-0.7781513\tt h
+
+\\end\\"""
+
+
+@pytest.mark.parametrize(
+    ["input_tensor", "lm_weight", "expected_result"],
+    [
+        (torch.tensor([
+            [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
+            [[-2.1, -0.1, -0.3, -4.2, -5.0, -5.1, -4.7, -4.2, -5.2, -1.2]],
+            [[-2.1, -2.5, -4.1, -4.2, -5.0, -0.7, -0.9, -1.7, -5.2, -1.2]],
+            [[-2.1, -0.5, -4.1, -4.2, -5.0, -0.7, -0.1, -1.1, -5.2, -1.2]],
+        ]), 
+        0, 
+        "tast"
+    ), (torch.tensor(
+        [
+            [[-2.1, -1.3, -4.1, -4.2, -5.0, -5.1, -0.2, -4.2, -5.2, -1.2]],
+            [[-2.1, -0.1, -0.3, -4.2, -5.0, -5.1, -4.7, -4.2, -5.2, -1.2]],
+            [[-2.1, -2.5, -4.1, -4.2, -5.0, -0.7, -0.9, -1.7, -5.2, -1.2]],
+            [[-2.1, -0.5, -4.1, -4.2, -5.0, -0.7, -0.1, -1.1, -5.2, -1.2]],
+        ]
+    ), 1, "test")
+    ]
+)
+def test_lm_decoding_weight(tmpdir, input_tensor, lm_weight, expected_result):
+    tokens_path = Path(tmpdir) / "tokens.txt"
+    lexicon_path = Path(tmpdir) / "lexicon.txt"
+    arpa_path = Path(tmpdir) / "lm.arpa"
+    tokens_path.write_text(tokens, "utf-8")
+    lexicon_path.write_text(lexicon, "utf-8")
+    arpa_path.write_bytes(bytes(arpa_lm, "utf-8"))
+
+    decoder = CTCLanguageDecoder(
+        language_model_path=str(arpa_path), 
+        tokens_path=str(tokens_path), 
+        lexicon_path=str(lexicon_path),
+        language_model_weight=lm_weight
+        )
+
+    with open(tokens_path, "r") as f:
+        tokens_char = f.read().splitlines()
+
+    r = decoder(input_tensor)
+    expected_result_index = [tokens_char.index(char) for char in expected_result]
+    assert r["hyp"][0]==expected_result_index

--- a/tests/scripts/htr/decode_ctc_cli_test.py
+++ b/tests/scripts/htr/decode_ctc_cli_test.py
@@ -97,7 +97,14 @@ decode:
   output_space: ' '
   segmentation: null
   print_line_confidence_scores: false
-  print_word_confidence_scores: false"""
+  print_word_confidence_scores: false
+  use_language_model: false
+  language_model_path: null
+  language_model_weight: null
+  tokens_path: null
+  lexicon_path: null
+  unk_token: <unk>
+  blank_token: <ctc>"""
 
 
 def test_config_output():

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -12,7 +12,9 @@ def test_wildcard_import():
 
 def test_versions_match():
     # check __init__ version matches setup.py (installed) version
-    version = pkg_resources.require("laia")[0].version
+    version = pkg_resources.require("pylaia")[0].version
+    print(version)
+    print(__version__)
     assert __version__.startswith(version)
 
 

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -13,8 +13,6 @@ def test_wildcard_import():
 def test_versions_match():
     # check __init__ version matches setup.py (installed) version
     version = pkg_resources.require("pylaia")[0].version
-    print(version)
-    print(__version__)
     assert __version__.startswith(version)
 
 


### PR DESCRIPTION
Adding a function that performs beam search decoding using an N-gram language model (built either with SLIRM or KenLM). 

Main changes:
- Dependency to `torchaudio == 0.13` ;
- A new decoder `decoders/ctc_language_decoder.py`, based on torchaudio's [ctc_decoder](https://pytorch.org/audio/main/generated/torchaudio.models.decoder.ctc_decoder.html#torchaudio.models.decoder.ctc_decoder) ;
- New arguments in the `DecodeArgs` class (related to the language model) ;
- Tests.
