### PR TITLE
Use pytorch-lightning version 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scipy
 matplotlib
 # cpu version: nnutils-pytorch
 nnutils-pytorch-cuda
-pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@1d3724a
+pytorch-lightning==1.1.0
 torch==1.13
 torchvision==0.14
 jsonargparse[signatures]==4.7


### PR DESCRIPTION
Publishing a python wheel of the project fails because of the specific commit mentionned for pytorch-lightning.

The commit points to https://github.com/Lightning-AI/lightning/pull/4913 which is first present in version https://github.com/Lightning-AI/lightning/releases/tag/1.1.0

