### PR TITLE
Add CI steps to build and publish wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,9 @@ jobs:
       if: ${{ matrix.python == '3.8' }}
     - name: Build wheel
       name: python setup.py bdist_wheel
+      if: ${{ matrix.python == '3.8' }}
     - name: Publish package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      if: ${{ matrix.python == '3.8' }} && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files
 
-  pytest:
+  build:
     name: Python ${{ matrix.python }}
     runs-on: ubuntu-latest
     strategy:
@@ -41,3 +41,10 @@ jobs:
     - uses: codecov/codecov-action@v1
       # upload coverage only for main job
       if: ${{ matrix.python == '3.8' }}
+    - name: Build wheel
+      name: python setup.py bdist_wheel
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
@jpuigcerver Could you setup a Github secret on the repo to store a PyPI token ? 

I can provide you our token GPG-encrypted if you can share a public key.