### PR TITLE
Support PyTorch 1.13.X versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ matplotlib
 # cpu version: nnutils-pytorch
 nnutils-pytorch-cuda
 pytorch-lightning==1.1.0
-torch==1.13
+torch>=1.13<1.14
 torchvision==0.14
-torchaudio==0.13
+torchaudio>=0.13<0.14
 jsonargparse[signatures]==4.7
 dataclasses; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 nnutils-pytorch-cuda
 pytorch-lightning==1.1.0
 torch>=1.13<1.14
-torchvision==0.14
+torchvision>=0.14<0.15
 torchaudio>=0.13<0.14
 jsonargparse[signatures]==4.7
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
Loosen the pytorch requirements to support the full range of minor versions under 1.13