### PR TITLE
Fix torch-related requirements and update github badges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
     - id: check-yaml
     - id: trailing-whitespace
     - id: end-of-file-fixer
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
     - id: isort
       args: [--profile, black]
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     - id: black

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 [![Coverage](https://img.shields.io/codecov/c/github/jpuigcerver/PyLaia?&label=Coverage&logo=Codecov&logoColor=ffffff&labelColor=f01f7a)](https://codecov.io/gh/jpuigcerver/PyLaia)
 [![Code quality](https://img.shields.io/codefactor/grade/github/jpuigcerver/PyLaia?&label=CodeFactor&logo=CodeFactor&labelColor=2782f7)](https://www.codefactor.io/repository/github/jpuigcerver/PyLaia)
 
-[![Python: 3.6+](https://img.shields.io/badge/Python-3.6%2B-FFD43B.svg?&logo=Python&logoColor=white&labelColor=306998)](https://www.python.org/)
-[![PyTorch: 1.4.0+](https://img.shields.io/badge/PyTorch-1.4.0%2B-8628d5.svg?&logo=PyTorch&logoColor=white&labelColor=%23ee4c2c)](https://pytorch.org/)
+[![Python: 3.8+](https://img.shields.io/badge/Python-3.8%2B-FFD43B.svg?&logo=Python&logoColor=white&labelColor=306998)](https://www.python.org/)
+[![PyTorch: 1.13.0+](https://img.shields.io/badge/PyTorch-1.13.0%2B-8628d5.svg?&logo=PyTorch&logoColor=white&labelColor=%23ee4c2c)](https://pytorch.org/)
 [![pre-commit: enabled](https://img.shields.io/badge/pre--commit-enabled-76877c?&logo=pre-commit&labelColor=1f2d23)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?)](https://github.com/ambv/black)
 

--- a/laia/callbacks/decode.py
+++ b/laia/callbacks/decode.py
@@ -84,7 +84,6 @@ class Decode(pl.Callback):
             word_probs = []
 
         for i, (img_id, hyp) in enumerate(zip(img_ids, hyps)):
-
             if self.use_symbols:
                 hyp = [self.syms[v] for v in hyp]
                 if self.convert_spaces:
@@ -96,7 +95,6 @@ class Decode(pl.Callback):
                 hyp = self.join_string.join(str(x) for x in hyp).strip()
 
             if self.print_confidence_scores:
-
                 if self.print_word_confidence_scores:
                     word_prob = [f"{prob:.2f}" for prob in word_probs[i]]
                     self.write(

--- a/laia/decoders/ctc_language_decoder.py
+++ b/laia/decoders/ctc_language_decoder.py
@@ -33,7 +33,6 @@ class CTCLanguageDecoder:
         unk_token: str = "<unk>",
         sil_token: str = "<space>",
     ):
-
         self.decoder = ctc_decoder(
             lm=language_model_path,
             lexicon=lexicon_path,

--- a/laia/nn/resnet.py
+++ b/laia/nn/resnet.py
@@ -128,7 +128,6 @@ class ResnetOptions:
         width_per_group: int = 64,
         norm_layer: Optional[Type[nn.Module]] = None,
     ):
-
         if len(layers) != 4:
             raise ValueError("The length of layers should be 4")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ matplotlib
 # cpu version: nnutils-pytorch
 nnutils-pytorch-cuda
 pytorch-lightning==1.1.0
-torch>=1.13<1.14
-torchvision>=0.14<0.15
-torchaudio>=0.13<0.14
+torch>=1.13,<1.14
+torchvision>=0.14,<0.15
+torchaudio>=0.13,<0.14
 jsonargparse[signatures]==4.7
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
Installing Pylaia via Pypi does not install the expected `torch` and `torchvision` versions.

```sh
$ pip install pylaia
Collecting pylaia
  Downloading pylaia-1.0.4-py3-none-any.whl (84 kB)
Collecting torchvision>=0.14<0.15
  Downloading torchvision-0.15.1-cp38-cp38-manylinux1_x86_64.whl (33.8 MB)
Collecting torch>=1.13<1.14
  Downloading torch-2.0.0-cp38-cp38-manylinux1_x86_64.whl (619.9 MB)
```

There was a missing `,` in the requirements file.
```sh
Collecting torch<1.14,>=1.13
  Using cached torch-1.13.1-cp310-cp310-manylinux1_x86_64.whl (887.5 MB)
Collecting torchvision<0.15,>=0.14
  Using cached torchvision-0.14.1-cp310-cp310-manylinux1_x86_64.whl (24.2 MB)
Collecting torchaudio<0.14,>=0.13
  Downloading torchaudio-0.13.1-cp310-cp310-manylinux1_x86_64.whl (4.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.2/4.2 MB 5.1 MB/s eta 0:00:00
```

I also updated github badges that were still set to `Python3.6+` while we use `Python3.8` for CI and `Pytorch 1.4+` while we use version 1.13+ now.