### PR TITLE
Replace deprecated pillow attribute

### DIFF
--- a/laia/data/transforms/vision/transforms.py
+++ b/laia/data/transforms/vision/transforms.py
@@ -83,7 +83,7 @@ class ToImageTensor:
         img: Image.Image,
         fw: Optional[int] = None,
         fh: Optional[int] = None,
-        resample: int = Image.ANTIALIAS,
+        resample: int = Image.Resampling.LANCZOS,
     ) -> Image.Image:
         if fw and fh:
             # resize to a fixed size


### PR DESCRIPTION
The `Image.ANTIALIAS` resampling method has been deprecated for a few versions of Pillow and has now been removed. It was making the tests fail with

```
E   AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'
```

I replaced it with `Image.Resample.Lanczos` as this is the [new name of this filter](https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html#antialias-renamed-to-lanczos).