### PR TITLE
Pad invalid images

### DIFF
--- a/laia/engine/data_module.py
+++ b/laia/engine/data_module.py
@@ -30,6 +30,7 @@ class DataModule(pl.LightningDataModule):
         va_txt_table: Optional[str] = None,
         te_img_list: Optional[Union[str, List[str]]] = None,
         batch_size: int = 8,
+        min_valid_size: int = None,
         color_mode: str = "L",
         shuffle_tr: bool = True,
         augment_tr: bool = False,
@@ -38,7 +39,7 @@ class DataModule(pl.LightningDataModule):
     ) -> None:
         assert stage in ("fit", "test")
         base_img_transform = transforms.vision.ToImageTensor(
-            mode=color_mode, invert=True
+            mode=color_mode, invert=True, min_width=min_valid_size
         )
         self.img_dirs = img_dirs
         self.img_channels = len(color_mode)
@@ -54,6 +55,7 @@ class DataModule(pl.LightningDataModule):
             tr_img_transform = transforms.vision.ToImageTensor(
                 mode=color_mode,
                 invert=True,
+                min_width=min_valid_size,
                 random_transform=transforms.vision.RandomBetaAffine()
                 if augment_tr
                 else None,

--- a/laia/models/htr/laia_crnn.py
+++ b/laia/models/htr/laia_crnn.py
@@ -153,9 +153,7 @@ class LaiaCRNN(nn.Module):
             xs = l.get_batch_output_size(xs)
         return xs
 
-    def get_min_valid_image_size(
-        self, max_search_size=128
-    ) -> Union[torch.LongTensor, int]:
+    def get_min_valid_image_size(self, max_search_size: int = 128) -> int:
         for size in range(max_search_size):
             xs = self.get_self_conv_output_size(torch.tensor([[size, size]]))
             if torch.count_nonzero(xs) == 2:

--- a/laia/models/htr/laia_crnn.py
+++ b/laia/models/htr/laia_crnn.py
@@ -152,3 +152,16 @@ class LaiaCRNN(nn.Module):
         for l in self.conv:
             xs = l.get_batch_output_size(xs)
         return xs
+
+    def get_min_valid_image_size(
+        self, max_search_size=128
+    ) -> Union[torch.LongTensor, int]:
+        for size in range(max_search_size):
+            xs = self.get_self_conv_output_size(torch.tensor([[size, size]]))
+            if torch.count_nonzero(xs) == 2:
+                return size
+        raise ValueError(
+            f"Images of size {max_search_size} pixels "
+            f"would produce invalid output sizes. "
+            f"Please review your model architecture."
+        )

--- a/laia/scripts/htr/create_model.py
+++ b/laia/scripts/htr/create_model.py
@@ -49,6 +49,9 @@ def run(
         "Model has {} parameters",
         sum(param.numel() for param in model.parameters()),
     )
+    log.info(
+        f"Minimum image size for this architecture: {model.get_min_valid_image_size(fixed_input_height)}"
+    )
     if save_model:
         ModelSaver(common.train_path, common.model_filename).save(
             LaiaCRNN, **vars(crnn)

--- a/laia/scripts/htr/train_ctc.py
+++ b/laia/scripts/htr/train_ctc.py
@@ -79,6 +79,7 @@ def run(
         tr_txt_table=tr_txt_table,
         va_txt_table=va_txt_table,
         batch_size=data.batch_size,
+        min_valid_size=model.get_min_valid_image_size(),
         color_mode=data.color_mode,
         shuffle_tr=not bool(trainer.limit_train_batches),
         augment_tr=train.augment_training,


### PR DESCRIPTION
When training PyLaia, an exception can be raised when some images are too small for convolutions.
```
Exception "ValueError('The images at batch indices [7] with sizes [[128, 5]] would produce invalid output sizes [[16, 0]]')
```

I propose to pad images to a minimum width of `x` pixels, `x` being the minimum valid width (depends on CNN parameters). 
