### PR TITLE
Normalize score after LM decoding

### DIFF
--- a/laia/callbacks/decode.py
+++ b/laia/callbacks/decode.py
@@ -70,9 +70,14 @@ class Decode(pl.Callback):
         img_ids = pl_module.batch_id_fn(batch)
         hyps = self.decoder(outputs)["hyp"]
 
-        if self.print_confidence_scores:
+        line_probs = (
+            self.decoder(outputs)["prob-htr"]
+            if self.print_line_confidence_scores
+            else []
+        )
+
+        if self.print_word_confidence_scores:
             probs = self.decoder(outputs)["prob-htr-char"]
-            line_probs = [np.mean(prob) for prob in probs]
             word_probs = [
                 compute_word_prob(self.syms, hyp, prob, self.input_space)
                 for hyp, prob in zip(hyps, probs)
@@ -80,7 +85,6 @@ class Decode(pl.Callback):
 
         else:
             probs = []
-            line_probs = []
             word_probs = []
 
         for i, (img_id, hyp) in enumerate(zip(img_ids, hyps)):

--- a/laia/decoders/ctc_greedy_decoder.py
+++ b/laia/decoders/ctc_greedy_decoder.py
@@ -75,6 +75,7 @@ class CTCGreedyDecoder:
 
         # Return char-based probability
         out["prob-htr-char"] = [prob.tolist() for prob in probs]
+        out["prob-htr"] = [prob.mean().item() for prob in probs]
         return out
 
     @staticmethod

--- a/laia/decoders/ctc_language_decoder.py
+++ b/laia/decoders/ctc_language_decoder.py
@@ -44,6 +44,7 @@ class CTCLanguageDecoder:
             sil_token=sil_token,
         )
         self.temperature = temperature
+        self.language_model_weight = language_model_weight
 
     def __call__(
         self,
@@ -85,5 +86,12 @@ class CTCLanguageDecoder:
         # Format the output
         out = {}
         out["hyp"] = [hypothesis[0].tokens.tolist() for hypothesis in hypotheses]
-        # you can get a log likelihood with hypothesis[0].score
+
+        # Normalize confidence score
+        out["prob-htr"] = [
+            np.exp(
+                hypothesis[0].score / ((self.language_model_weight + 1) * length.item())
+            )
+            for hypothesis, length in zip(hypotheses, batch_sizes)
+        ]
         return out

--- a/laia/scripts/htr/decode_ctc.py
+++ b/laia/scripts/htr/decode_ctc.py
@@ -73,8 +73,7 @@ def run(
             sil_token=decode.input_space,
             temperature=decode.temperature,
         )
-        # confidence scores are not supported when using a language model
-        decode.print_line_confidence_scores = False
+        # word-level confidence scores are not supported when using a language model
         decode.print_word_confidence_scores = False
 
     else:

--- a/tests/callbacks/decode_test.py
+++ b/tests/callbacks/decode_test.py
@@ -15,6 +15,7 @@ class _TestDecoder:
             "prob-htr-char": [
                 [0.9, 0.9, 0.9, 0.9, 0.9, 0.9] for _ in range(batch_size)
             ],
+            "prob-htr": [0.9 for _ in range(batch_size)],
         }
 
 


### PR DESCRIPTION
CTCDecoder with language model returns the log-likelihood of the hypothesis. We should normalize this value and output a confidence score. 